### PR TITLE
Adding timeout at the end before the script ends

### DIFF
--- a/docs/assets/scripts/Get-OmbiUpdate.ps1
+++ b/docs/assets/scripts/Get-OmbiUpdate.ps1
@@ -112,3 +112,4 @@ else
 Write-Host ($OmbiCurrent.version + " is the latest version.")
 }
 #endregion
+timeout 5


### PR DESCRIPTION
Timeout command prevents the script from closing right away.