### PR TITLE
Reverse Proxy Doc SSL update

### DIFF
--- a/docs/guides/mobile-app.md
+++ b/docs/guides/mobile-app.md
@@ -35,3 +35,6 @@ Make sure the application url is set to your externally accessible domain for Om
 e.g. the demo site uses `https://demo.ombi.io/`  
 
 A good idea is to set this up using a [Reverse Proxy](../../info/reverse-proxy), rather than simply forwarding a port.
+
+**If you experience a "Wrong Server Version" error** from your device, but browsing from your PC/Computer/Other devices is working.  You might have issues with your SSL configuration.
+Review the [Reverse Proxy](../../info/reverse-proxy) page for additional details.

--- a/docs/info/reverse-proxy.md
+++ b/docs/info/reverse-proxy.md
@@ -12,6 +12,19 @@ These include:
 - Providing a nice URL for users to access (instead of `http://your.external.ip.address:port`).
 - Providing a layer of SSL security for your Ombi users.
 
+## SSL/TLS Configuration
+
+When configuring SSL/TLS for your reverse proxy, you may need to provide the fullchain SSL certificate. This is especially important when using certificate providers like Let's Encrypt or ZeroSSL.
+
+**Why Fullchain SSL Certificates?**
+
+Fullchain certificates include both your domain certificate and the intermediate certificates, ensuring that clients can validate the entire chain of trust. Without the fullchain certificate, clients might experience SSL errors, leading to failed connections.
+Some Android users have reported that using only the domain certificate and not providing the intermediate certificate has caused errors, resulting in "Wrong Server Version" messages in the app.
+
+**Using Let's Encrypt or ZeroSSL**
+
+If you are using Let's Encrypt or ZeroSSL, the certificate generation process typically provides a fullchain certificate. Ensure that you configure your reverse proxy to use this certificate for proper SSL/TLS setup.
+
 ### A "nice URL"?
 
 By default, the internet uses IP addresses to communicate. A service called DNS provides a way to alias these addresses with nice names (`www.example.com`, for example), rather than the direct IP address. Think of it like a phonebook for the internet, allowing you to look up a more complicated entry with an easy to remember name.  


### PR DESCRIPTION
Modify docs to add hint regarding LE and ZeroSSL and needing to use the fullchain certificate.
This should guide / help users with the "Wrong Server Version" from Android devices behind SSL reverse proxies using LetsEncrypt/Acme.sh/ZeroSSL etc.