### PR TITLE
Update "win10-xxx" to be "win-xxx" for update/install docs

### DIFF
--- a/docs/assets/scripts/Get-OmbiUpdate.ps1
+++ b/docs/assets/scripts/Get-OmbiUpdate.ps1
@@ -21,7 +21,7 @@ param(
 # The name of the Ombi Service (Default: Ombi, can override)
 [Parameter(HelpMessage="The name of the Ombi Service (Default: Ombi, can override)")][string]$ServiceName = "Ombi",
 # The filename of the Ombi download
-[Parameter(HelpMessage="Filename of the Ombi archive to download")][string]$Filename = "Win10-x64.zip",
+[Parameter(HelpMessage="Filename of the Ombi archive to download")][string]$Filename = "win-x64.zip",
 # Is this a forced reinstall?
 [Parameter(HelpMessage="Is this a forced reinstall?")][Switch]$Force
 )

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -42,14 +42,14 @@ If you are running docker, place these files into the folder you've passed into 
 ## Windows
 
 === "V4"
-    1. Download the latest `win10-xxx.zip` (x64 or x86 depends on your system) from [Ombi Releases](https://github.com/Ombi-app/Ombi/releases/latest)
+    1. Download the latest `win-xxx.zip` (x64 or x86 depends on your system) from [Ombi Releases](https://github.com/Ombi-app/Ombi/releases/latest)
     1. Right click the file > Properties > Unblock
     1. Extract the zip to your preferred directory.  
     **DO NOT** place in the "Program Files" or "ProgramData" folders as the Ombi database will be locked.
     1. Run Ombi.exe
 
 === "V4 (Develop)"
-    1. Download the latest `win10-xxx.zip` (x64 or x86 depends on your system) from [Ombi Releases](https://github.com/Ombi-app/Ombi/releases)
+    1. Download the latest `win-xxx.zip` (x64 or x86 depends on your system) from [Ombi Releases](https://github.com/Ombi-app/Ombi/releases)
     1. Right click the file > Properties > Unblock
     1. Extract the zip to your preferred directory.  
     **DO NOT** place in the "Program Files" or "ProgramData" folders as the Ombi database will be locked.
@@ -59,7 +59,7 @@ If you are running docker, place these files into the folder you've passed into 
 
 (This is the preferred method on Windows)
 
-1. Download the latest `win10-xxx.zip` (x64 or x86 depends on your system) from [Ombi Releases](https://github.com/Ombi-app/Ombi/releases)
+1. Download the latest `win-xxx.zip` (x64 or x86 depends on your system) from [Ombi Releases](https://github.com/Ombi-app/Ombi/releases)
 1. Right click > Properties > Unblock
 1. Extract the zip to your preferred directory.  
 In the example configs below, we've put the contents of the archive into `C:\Tools\Ombi`.

--- a/docs/guides/updating.md
+++ b/docs/guides/updating.md
@@ -71,7 +71,7 @@ To do so is fairly straightforward.
     2. Back up the `database.json` file from the Ombi directory.  
     This defines how ombi connects to the MySQL server.
     1. Delete the contents of the Ombi directory, _excluding_ the files mentioned in step 2.
-    2. Download the latest `win10-x86.zip` or `win10-x64.zip` from the link below:  
+    2. Download the latest `win-x86.zip` or `win-x64.zip` from the link below:  
         [Stable](https://github.com/Ombi-app/Ombi/releases/latest)  
         [Develop](https://github.com/Ombi-app/Ombi/releases)
     3. Extract the zip to your Ombi directory.
@@ -122,7 +122,7 @@ This is where the script will download to. It's only required if you don't want 
 - ServiceName  
 Most of us just use 'Ombi', so it's the default. If you used something different, pass in this argument with whatever you used.
 - Filename  
-This is only for if you are using x86. If this is the case, pass in `Win10-x86.zip` as the argument. Default is `Win10-x64.zip`.  
+This is only for if you are using x86. If this is the case, pass in `win-x86.zip` as the argument. Default is `win-x64.zip`.  
 - Force  
 
 This is a simple true/false switch - it will force the script to install the newest version, even if it's already installed. If the argument isn't there, it's a `false`. The moment you add `-Force` to the end of the command you'd normally use to run this script, it'll be `true` and force a reinstall.


### PR DESCRIPTION
Changed references to "win10-xxx" to be "win-xxx" instead to match the releases since v4.43.20.